### PR TITLE
Caches user id and group id on startup. pwd.getpwnam() and grp.getgrnam() were not working after chroot on ubuntu or centos

### DIFF
--- a/lust/server.py
+++ b/lust/server.py
@@ -23,6 +23,8 @@ class Simple(object):
         self.uid = self.config.get(name + '.uid', uid)
         self.gid = self.config.get(name + '.gid', gid)
 
+        self.unum, self.gnum = unix.get_user_info(uid, gid)
+
 
     def before_daemonize(self, args):
         pass
@@ -90,7 +92,7 @@ class Simple(object):
 
         self.before_drop_privs(args)
 
-        unix.drop_privileges(uid_name=self.uid, gid_name=self.gid)
+        unix.drop_privileges(self.unum, self.gnum)
 
         log.info("Server %s running." % self.name)
         self.start(args)

--- a/lust/unix.py
+++ b/lust/unix.py
@@ -86,13 +86,16 @@ def chroot_jail(root="/tmp"):
     os.chdir("/")
 
 
-def drop_privileges(uid_name='nobody', gid_name='nogroup'):
+def get_user_info(uid, gid):
+    return (
+        pwd.getpwnam(uid).pw_uid,
+        grp.getgrnam(gid).gr_gid,
+    )
+
+
+def drop_privileges(running_uid, running_gid):
     if os.getuid() != 0:
         return
-
-    # Get the uid/gid from the name
-    running_uid = pwd.getpwnam(uid_name).pw_uid
-    running_gid = grp.getgrnam(gid_name).gr_gid
 
     log.info("Dropping pivs to UID %r GID %r" % (running_uid, running_gid))
 

--- a/tests/simple_test_server.py
+++ b/tests/simple_test_server.py
@@ -34,7 +34,7 @@ class SimpleDaemon(server.Simple):
 
 if __name__ == "__main__":
     # if you're on OSX then change this to whatever user nd group
-    server = SimpleDaemon("simpledaemon", uid='zedshaw', gid='staff', 
+    server = SimpleDaemon("simpledaemon", uid='nobody', gid='nogroup', 
                           pid_file_path=RUN_DIR, run_base=RUN_DIR, log_dir=RUN_DIR)
     server.run(sys.argv)
 

--- a/tests/unix_tests.py
+++ b/tests/unix_tests.py
@@ -100,6 +100,18 @@ def test_chroot_jail(chroot_jail):
 
 @patch("pwd.getpwnam")
 @patch("grp.getgrnam")
+@patch("os.getuid")
+def test_get_user_info(os_getuid, *calls):
+    # fakes out os.getuid to claim it's running as root
+    os_getuid.return_value = 0
+
+    unix.get_user_info('root', 'root')
+
+    # now just confirm all the remaining system calls were called
+    for i in calls:
+        assert_true(i.called, "Failed to call %r" % i)
+
+
 @patch("os.setgroups")
 @patch("os.setgid")
 @patch("os.setuid")
@@ -109,22 +121,23 @@ def test_drop_privileges(os_getuid, *calls):
     # fakes out os.getuid to claim it's running as root
     os_getuid.return_value = 0
 
-    unix.drop_privileges()
+    unix.drop_privileges(501, 501)
 
     # now just confirm all the remaining system calls were called
     for i in calls:
         assert_true(i.called, "Failed to call %r" % i)
 
 
+@patch("os.setuid")
 @patch("os.getuid")
-@patch("pwd.getpwnam")
-def test_drop_privileges_not_root(pwd_getpwnam, os_getuid):
+def test_drop_privileges_not_root(os_getuid, os_setuid):
     # fakes out os.getuid to claim it's running as root
     os_getuid.return_value = 1000
-    unix.drop_privileges()
+    unix.drop_privileges(501, 501)
 
     assert_true(os_getuid.called)
-    assert_false(pwd_getpwnam.called)
+    assert_false(os_setuid.called)
+
 
 @patch("signal.signal")
 def test_register_shutdown(signal_signal):


### PR DESCRIPTION
Using 1.0.3, the following daemon would fail:

``` py
import sys
import time
from lust import log, server

class TestDaemon(server.Simple):
    def start(self, args):
        time.sleep(30)

    def shutdown(self, signal):
        log.info("Shutting down now signal: %d" % signal)

if __name__ == "__main__":
    server = TestDaemon("testd", uid='nobody', gid='nogroup', log_dir='/tmp')
    server.run(sys.argv)
```

Exception:

```
KeyError: 'getpwnam(): name not found: nobody'
```

The user ID lookup happening in `drop_privileges` was failing after the `chroot`, so I moved it to the server startup. Not sure if this fits in with the project's style or goals, or if it's even a good solution, but lust now works great for me with this change so hopefully it's useful.
